### PR TITLE
bugfix: action cableのマウントを無効化

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,8 @@ module Myapp
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    config.action_cable.mount_path = nil
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files


### PR DESCRIPTION
## 概要
デプロイ時にAction Cableの設定に関するエラーが発生したため、修正。
## 変更内容
- action cableのマウントを無効化するために、config/application.rbに下記の記述を追加。
config.action_cable.mount_path = nil
## 確認方法
- [ ] 正常にデプロイできるか。

Ref #47 