### PR TITLE
Add initial scehma.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,17 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.1].define(version: 0) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+
+end


### PR DESCRIPTION
## 概要
デプロイ時にAction Cableの設定に関するエラーが発生していたが、その根本原因を「ローカル環境でのマイグレーションが未実行で、db/schema.rbが存在しないこと」だと考えた。
そのため、ローカル環境でマイグレーションを実行した。
## 変更内容
マイグレーション初実行により、db/schema.rbを追加。
## 確認方法
- [ ] 正常にデプロイできるか

Ref #47 