### PR TITLE
bugfix: データベースのcacheの設定の追加

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -24,3 +24,6 @@ production:
   queue:
     <<: *default
     url: <%= ENV['DATABASE_URL'] %>
+  cache:
+    <<: *default
+    url: <%= ENV['DATABASE_URL'] %>


### PR DESCRIPTION
## 概要
デプロイ時に、cacheの設定に関するエラーが発生したため、修正。
## 変更内容
config/database.ymlのproductinセクションにcacheの設定を追加。
## 確認方法
- [ ] 正常にデプロイできるか

Ref #47 