### PR TITLE
add: アカウント設定編集機能を実装

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,7 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+// ヘッダのドロップダウン
+import Dropdown from '@stimulus-components/dropdown'
+application.register('dropdown', Dropdown)

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,79 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+  <div class="max-w-md w-full bg-white rounded-lg shadow-md p-8">
+    <div class="mb-8">
+      <h2 class="text-3xl font-bold text-gray-900 text-center">アカウント設定</h2>
+      <p class="mt-2 text-center text-sm text-gray-600">
+        登録情報を更新できます
+      </p>
+    </div>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: "space-y-6" }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+      <div>
+        <%= f.label :email, "メールアドレス", class: "block text-sm font-medium text-gray-700 mb-2" %>
+        <%= f.email_field :email, 
+            autofocus: true, 
+            autocomplete: "email",
+            class: "w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent" %>
+      </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
+      <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+        <div class="text-sm text-amber-600 bg-amber-50 p-3 rounded-lg">
+          確認待ち: <%= resource.unconfirmed_email %>
+        </div>
+      <% end %>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+      <div>
+        <%= f.label :password, class: "block text-sm font-medium text-gray-700 mb-2" do %>
+          パスワード
+          <span class="text-xs text-gray-500">(変更しない場合は空欄のままにしてください)</span>
+        <% end %>
+        <%= f.password_field :password, 
+            autocomplete: "new-password",
+            class: "w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent" %>
+        <% if @minimum_password_length %>
+          <p class="mt-1 text-xs text-gray-500"><%= @minimum_password_length %> 文字以上</p>
+        <% end %>
+      </div>
+
+      <div>
+        <%= f.label :password_confirmation, "パスワード確認", class: "block text-sm font-medium text-gray-700 mb-2" %>
+        <%= f.password_field :password_confirmation, 
+            autocomplete: "new-password",
+            class: "w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent" %>
+      </div>
+
+      <div>
+        <%= f.label :current_password, "現在のパスワード", class: "block text-sm font-medium text-gray-700 mb-2" do %>
+          現在のパスワード
+          <span class="text-xs text-gray-500">(変更を確認するために必要です)</span>
+        <% end %>
+        <%= f.password_field :current_password, 
+            autocomplete: "current-password",
+            class: "w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent" %>
+      </div>
+
+      <div>
+        <%= f.submit "更新", 
+            class: "w-full py-3 px-4 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition font-semibold focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900" %>
+      </div>
     <% end %>
+
+    <div class="mt-8 pt-6 border-t border-gray-200">
+      <h3 class="text-lg font-semibold text-gray-900 mb-4">アカウントの削除</h3>
+      <p class="text-sm text-gray-600 mb-4">
+        アカウントを削除すると、すべてのデータが失われます。この操作は取り消せません。
+      </p>
+      <%= button_to "アカウントを削除する", 
+          registration_path(resource_name), 
+          data: { confirm: "本当にアカウントを削除しますか？この操作は取り消せません。", turbo_confirm: "本当にアカウントを削除しますか？" }, 
+          method: :delete,
+          class: "w-full py-2 px-4 border-2 border-red-500 text-red-500 rounded-lg hover:bg-red-500 hover:text-white transition font-semibold" %>
+    </div>
+
+    <div class="mt-6 text-center">
+      <%= link_to "戻る", :back, class: "text-sm text-gray-600 hover:text-gray-900 transition" %>
+    </div>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,10 +7,39 @@
 
       <% if user_signed_in? %>
         <!-- ログイン中の表示 -->
-        <div>
-          <%= link_to 'ログアウト', destroy_user_session_path, 
-              data: { turbo_method: :delete }, 
-              class: "px-4 py-2 border-2 border-red-500 text-red-500 rounded hover:bg-red-500 hover:text-white transition font-semibold" %>
+        <div data-controller="dropdown" class="relative">
+          <button 
+            type="button" 
+            data-action="dropdown#toggle click@window->dropdown#hide"
+            class="flex items-center space-x-2 px-4 py-2 rounded hover:bg-gray-800 transition"
+          >
+            <span><%= current_user.name %></span>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+            </svg>
+          </button>
+          <div
+            data-dropdown-target="menu"
+            class="hidden transition transform origin-top-right absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5"
+            data-transition-enter-from="opacity-0 scale-95"
+            data-transition-enter-to="opacity-100 scale-100"
+            data-transition-leave-from="opacity-100 scale-100"
+            data-transition-leave-to="opacity-0 scale-95"
+          >
+            <div class="py-1">
+              <%= link_to edit_user_registration_path, 
+                  data: { action: "dropdown#toggle" },
+                  class: "block px-4 py-2 text-gray-700 hover:bg-gray-100 transition" do %>
+                アカウント設定
+              <% end %>
+              <%= button_to destroy_user_session_path, 
+                  method: :delete,
+                  data: { action: "dropdown#toggle" },
+                  class: "block w-full text-left px-4 py-2 text-gray-700 hover:bg-gray-100 transition" do %>
+                ログアウト
+              <% end %>
+            </div>
+          </div>
         </div>
       <% else %>
         <!-- 非ログイン時の表示 -->

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.20",
     "@popperjs/core": "^2.11.8",
+    "@stimulus-components/dropdown": "^3.0.0",
     "@tailwindcss/cli": "^4.1.18",
     "autoprefixer": "^10.4.23",
     "nodemon": "^3.1.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -314,6 +314,13 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-8.1.100.tgz#b1f85f3482425fb91e5eba1deb55152ee0bb2f85"
   integrity sha512-j4vJQqz51CDVYv2UafKRu4jiZi5/gTnm7NkyL+VMIgEw3s8jtVtmzu9uItUaZccUg9NJ6o05yVyBAHxNfTuCRA==
 
+"@stimulus-components/dropdown@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@stimulus-components/dropdown/-/dropdown-3.0.0.tgz#b85efa8ef06a94eac1a40e52ac920f5089789c8e"
+  integrity sha512-GY9Ez8T5Vbcad702seF4iuKZwv4f+VACtfO527l8vrFDFbGWWFyRljyK9FFXSPEkUC3/4PilVsYfPO2CMikkEg==
+  dependencies:
+    stimulus-use "^0.52.2"
+
 "@tailwindcss/cli@^4.1.18":
   version "4.1.18"
   resolved "https://registry.yarnpkg.com/@tailwindcss/cli/-/cli-4.1.18.tgz#c4a8d55da0bcac803b0d21fae168dde76d3f47a3"
@@ -992,6 +999,11 @@ source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
+
+stimulus-use@^0.52.2:
+  version "0.52.3"
+  resolved "https://registry.yarnpkg.com/stimulus-use/-/stimulus-use-0.52.3.tgz#d6f35fa93277274957a2ed98a7b04b4d702cb1d6"
+  integrity sha512-stZ5dID6FUrGCR/ChWUa0FT5Z8iqkzT6lputOAb50eF+Ayg7RzJj4U/HoRlp2NV333QfvoRidru9HLbom4hZVw==
 
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"


### PR DESCRIPTION
## 概要
アカウント設定編集画面で、メールアドレス・パスワードの変更、アカウントの削除ができるようにした。
## 対応issue
closes #19, #18   
## 備考
- deviseのデフォルト機能に「パスワードの変更」も含まれていたためが、消さずに残すことにした。
- メールアドレスやパスワードを変更するときに、「現在のパスワード」を入力しないといけない設定になっている。
- ヘッダのプルダウンは、「docker compose exec web yarn add @stimulus-components/dropdown」でstimulusのドロップダウンのパッケージをインストールして実装した。（下記ドキュメントを参考にした）
  - https://www.stimulus-components.com/docs/stimulus-dropdown/
## 確認方法
- [ ] ヘッダの右上のログインボタンからログイン
- [ ] ログイン時に、ヘッダの右上にユーザ名が表示されている
- [ ] その部分を押すと「アカウント設定」と「ログアウト」のプルダウンが出てくる
- [ ] ログアウトボタンを押した場合ログアウトできる。
- [ ] 「アカウント設定」を押した場合、アカウント設定編集画面に移る
- [ ] ユーザネーム、メールアドレス、パスワード、パスワード確認、現在のパスワードの入力フォームが機能する。
- [ ] 更新ボタンが機能する
- [ ] 「戻る」ボタンが機能する
- [ ] アカウント削除ボタンが機能する（押したときに、確認が表示される）