### PR TITLE
config: タイムゾーンを日本時間に設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,8 @@ module Myapp
     # デフォルトのロケールを日本語に設定
     config.i18n.default_locale = :ja
 
+    # タイムゾーンを日本時間に設定
+    config.time_zone = "Tokyo"
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files


### PR DESCRIPTION
## 概要
タイムゾーンを日本時間に設定

## 意図
Alarmモデルのカスタムバリデーション「scheduled_at_must_be_in_the_future」の働きを正確にチェックするため。