### PR TITLE
fix: Alarmのフラッシュメッセージが表示されない問題を修正

### DIFF
--- a/app/controllers/alarms_controller.rb
+++ b/app/controllers/alarms_controller.rb
@@ -18,7 +18,7 @@ class AlarmsController < ApplicationController
     if @alarm.save
       redirect_to alarms_path, notice: "アラームを作成しました"
     else
-      flash.now[:danger] = "アラームを作成できませんでした"
+      flash.now[:alert] = "アラームを作成できませんでした"
       render :new, status: :unprocessable_entity
     end
   end
@@ -33,7 +33,7 @@ class AlarmsController < ApplicationController
     if @alarm.update(alarm_params)
       redirect_to alarms_path, notice: "アラームを更新しました"
     else
-      flash.now[:danger] = "アラームを更新できませんでした"
+      flash.now[:alert] = "アラームを更新できませんでした"
       render :edit, status: :unprocessable_entity
     end
   end


### PR DESCRIPTION
## 概要
Alarmのcreate・updateの失敗時のフラッシュメッセージが表示されるように修正。
## 変更箇所
- app/controllers/alarms_controller.rb
  - createアクションの下記のdangerの部分をalertに変更。
  ```
  flash.now[:danger] = "アラームを作成できませんでした"
  ```
  - updateアクションの下記のdangerの部分をalertに変更。
  ```
  flash.now[:danger] = "アラームを更新できませんでした"
  ```
## 理由
#### <この修正方法を選んだ理由>
app/views/layouts/application.html.erbの下記の部分にdangerに関する記述がなく、現段階でdangerに関する記述を加える必要性は無いと判断したため。
```
        <main class="flex-1 p-6">
          <!-- フラッシュメッセージ関連 -->
          <% if notice %>
            <div class="mb-4 rounded-lg bg-green-50 p-4 text-green-800 border border-green-200" role="alert">
              <%= notice %>
            </div>
          <% end %>
          <% if alert %>
            <div class="mb-4 rounded-lg bg-red-50 p-4 text-red-800 border border-red-200" role="alert">
              <%= alert %>
            </div>
          <% end %>

          <%= yield %>
        </main>
```
## 確認方法
- サイドバーの「アラーム」をクリックして、アラーム一覧画面へ遷移。
- 「アラームを作成」をクリック
- 日時設定をせずに作成ボタンをクリック
- [ ] 「アラームを作成できませんでした」というフラッシュメッセージが表示される。
- ラベルと、日時設定（未来の日時）を入力して、アラームを作成
- 一覧画面で、更新ボタンをクリック
- ラベルの入力を消して、更新ボタンをクリック
- [ ] 「アラームを更新できませんでした」というフラッシュメッセージが表示される。