### PR TITLE
update: メール送信元を独自ドメインに変更

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "onboarding@resend.dev"
+  default from: "#{ENV['EMAIL_FROM_NAME']} <noreply@#{ENV['EMAIL_FROM_DOMAIN']}>"
   layout "mailer"
 end


### PR DESCRIPTION
## 概要
メールの送信元を、「resendの共有ドメイン」から独自ドメインに変更した。
## 背景
共有ドメインのままだと、一般ユーザに対してメールを送信することができないため。
## 備考
- renderのダッシュボードで環境変数（EMAIL_FROM_NAME、EMAIL_FROM_DOMAIN）を設定済み。
- resendでの独自ドメイン認証の参考記事：https://zenn.dev/shigerufukada/articles/e5aedf6ec7a969
## 確認方法
- [ ] 本番環境で、メールの送信先が制限されていないか確認。（基本的にどのメールアドレスにも届くようになっているか）