### PR TITLE
security: emailの重複エラー時のバリデーションエラーを変更

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,6 @@
 class Users::RegistrationsController < Devise::RegistrationsController
-  before_action :configure_sign_up_params, only: [:create]
-  before_action :configure_account_update_params, only: [:update]
+  before_action :configure_sign_up_params, only: [ :create ]
+  before_action :configure_account_update_params, only: [ :update ]
 
   #=======================================================
   # publicメソッド
@@ -42,11 +42,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # protectedメソッド
   #=======================================================
   def configure_sign_up_params
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :attribute ])
   end
 
   def configure_account_update_params
-    devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :attribute ])
   end
 
   def after_sign_up_path_for(resource)
@@ -66,7 +66,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def sanitize_email_uniqueness_error(resource)
     if resource.errors.details[:email].any? { |e| e[:error] == :taken } # エラー情報の中に重複エラーが含まれているか確認
       resource.errors.delete(:email) # 具体的なエラーを削除
-      resource.errors.add(:base, '入力内容に誤りがあります。もう一度ご確認ください。') # 曖昧なエラーメッセージの追加
+      resource.errors.add(:base, "入力内容に誤りがあります。もう一度ご確認ください。") # 曖昧なエラーメッセージの追加
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   # ログイン認証
   #==============================================================
   # ※ユーザ情報用のコントローラのみカスタマイズバージョンを指定(users/registrations_controller.rb)
-  devise_for :users, controllers: { registrations: 'users/registrations' }
+  devise_for :users, controllers: { registrations: "users/registrations" }
 
   #==============================================================
   # その他


### PR DESCRIPTION
## 概要
ユーザデータの作成・更新の際の、emailの重複エラー時のバリデーションエラーを、具体的なエラー（重複エラー）から曖昧なエラーに変更
## 背景
登録されているメールアドレスをバリデーションエラーから特定されないようにするため。
## 備考
deviseの内部のコントローラの仕組みを、app/controllers/users/registrations_controller.rbを編集する形でカスタマイズした。
## 確認方法
- [ ] アカウント登録、アカウント設定編集の際に、emailの重複エラーに引っ掛かったときに、「入力内容に誤りがあります。もう一度ご確認ください。」というフォームエラーが表示されるか確認
- [ ] また、エラーの種類が曖昧なものになっているか（「taken」が含まれていないか）をコンソールで確認。
## 関連issue
Ref #104 