### PR TITLE
feat: フォームに必須マークと補足説明を追加

### DIFF
--- a/app/views/alarms/edit.html.erb
+++ b/app/views/alarms/edit.html.erb
@@ -3,17 +3,27 @@
     <%# バリデーションエラー表示用のパーシャルを読込 %>
     <%= render 'shared/error_messages', object: f.object %>
 
+    <p class="text-sm text-gray-600 mb-4">
+      <span class="text-red-600">*</span>がついているのは必須項目です
+    </p>
+
     <div>
-      <%= f.label :label, 'ラベル', class: "block text-gray-700 font-semibold mb-2" %>
+      <%= f.label :label, class: "block text-gray-700 font-semibold mb-2" do %>
+        ラベル<span class="text-red-600">*</span>
+      <% end %>
       <%= f.text_field :label, 
           placeholder: 'アラーム', 
           class: "w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-gray-500 focus:border-transparent" %>
     </div>
 
     <div>
-      <%= f.label :scheduled_at, '日時', class: "block text-gray-700 font-semibold mb-2" %>
+      <%= f.label :scheduled_at, class: "block text-gray-700 font-semibold mb-2" do %>
+        日時<span class="text-red-600">*</span>
+        
+      <% end %>
       <%= f.datetime_field :scheduled_at, 
           class: "w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-gray-500 focus:border-transparent" %>
+      <span class="text-xs text-gray-500 font-normal ml-2">(未来の日時のみ可)</span>
     </div>
 
     <div class="pt-4">

--- a/app/views/alarms/new.html.erb
+++ b/app/views/alarms/new.html.erb
@@ -4,18 +4,29 @@
   <div class="bg-white rounded-lg shadow-md p-6 max-w-2xl">
     <%= form_with model: @alarm, class: "space-y-6" do |f| %>
       <%# バリデーションエラー表示用のパーシャルを読込 %>
+
+      <p class="text-sm text-gray-600 mb-4">
+        <span class="text-red-600">*</span>がついているのは必須項目です
+      </p>
+
       <%= render 'shared/error_messages', object: f.object %>
       <div>
-        <%= f.label :label, 'ラベル', class: "block text-gray-700 font-semibold mb-2" %>
+        <%= f.label :label, class: "block text-gray-700 font-semibold mb-2" do %>
+          ラベル<span class="text-red-600">*</span>
+        <% end %>
         <%= f.text_field :label, 
             placeholder: 'アラーム', 
             class: "w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-gray-500 focus:border-transparent" %>
       </div>
 
       <div>
-        <%= f.label :scheduled_at, '日時', class: "block text-gray-700 font-semibold mb-2" %>
+        <%= f.label :scheduled_at, class: "block text-gray-700 font-semibold mb-2" do %>
+          日時<span class="text-red-600">*</span>
+          
+        <% end %>
         <%= f.datetime_field :scheduled_at, 
             class: "w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-gray-500 focus:border-transparent" %>
+        <span class="text-xs text-gray-500 font-normal ml-2">(未来の日時のみ可)</span>
       </div>
 
       <div class="flex items-center space-x-4 pt-4">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -10,6 +10,10 @@
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: "space-y-6" }) do |f| %>
       <%= render "devise/shared/error_messages", resource: resource %>
 
+      <p class="text-sm text-gray-600 mb-4">
+        <span class="text-red-600">*</span>がついているのは必須項目です
+      </p>
+
       <div>
         <%= f.label :email, "メールアドレス", class: "block text-sm font-medium text-gray-700 mb-2" %>
         <%= f.email_field :email, 
@@ -45,8 +49,8 @@
       </div>
 
       <div>
-        <%= f.label :current_password, "現在のパスワード", class: "block text-sm font-medium text-gray-700 mb-2" do %>
-          現在のパスワード
+        <%= f.label :current_password, class: "block text-sm font-medium text-gray-700 mb-2" do %>
+          現在のパスワード<span class="text-red-600">*</span>
           <span class="text-xs text-gray-500">(変更を確認するために必要です)</span>
         <% end %>
         <%= f.password_field :current_password, 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -10,8 +10,14 @@
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "space-y-6" }) do |f| %>
       <%= render "devise/shared/error_messages", resource: resource %>
 
+      <p class="text-sm text-gray-600 mb-4">
+        <span class="text-red-600">*</span>がついているのは必須項目です
+      </p>
+
       <div>
-        <%= f.label :name, class: "block text-sm font-medium text-gray-700 mb-2" %>
+        <%= f.label :name, class: "block text-sm font-medium text-gray-700 mb-2" do %>
+          名前<span class="text-red-600">*</span>
+        <% end %>
         <%= f.text_field :name, 
             autofocus: true, 
             autocomplete: "name",
@@ -19,7 +25,9 @@
       </div>
 
       <div>
-        <%= f.label :email, class: "block text-sm font-medium text-gray-700 mb-2" %>
+        <%= f.label :email, class: "block text-sm font-medium text-gray-700 mb-2" do %>
+          メールアドレス<span class="text-red-600">*</span>
+        <% end %>
         <%= f.email_field :email, 
             autocomplete: "email",
             class: "w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent" %>
@@ -27,18 +35,21 @@
 
       <div>
         <%= f.label :password, class: "block text-sm font-medium text-gray-700 mb-2" do %>
-          パスワード
-          <% if @minimum_password_length %>
-            <span class="text-xs text-gray-500">(<%= @minimum_password_length %> 文字以上)</span>
-          <% end %>
+          パスワード<span class="text-red-600">*</span>
+          
         <% end %>
         <%= f.password_field :password, 
             autocomplete: "new-password",
             class: "w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent" %>
+        <% if @minimum_password_length %>
+          <span class="text-xs text-gray-500">(<%= @minimum_password_length %> 文字以上)</span>
+        <% end %>
       </div>
 
       <div>
-        <%= f.label :password_confirmation, "パスワード確認", class: "block text-sm font-medium text-gray-700 mb-2" %>
+        <%= f.label :password_confirmation, class: "block text-sm font-medium text-gray-700 mb-2" do %>
+          パスワード確認<span class="text-red-600">*</span>
+        <% end %>
         <%= f.password_field :password_confirmation, 
             autocomplete: "new-password",
             class: "w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent" %>


### PR DESCRIPTION
## 概要
各作成・更新フォームをわかりやすくするために、必須マークや補足説明を追加した。
## 対応issue
closes #104 
## 確認方法
- [ ] アカウント作成画面の、名前、メールアドレス、パスワード、パスワード確認のラベルの横に「*（赤色）」がついている。また、フォームの上部に「*がついているのは必須項目です」という表示がある。
- [ ] アカウント設定編集画面に下記のように、必須項目と補足説明がついている。
[![Image from Gyazo](https://i.gyazo.com/e4045a22188203686cbcecbcded96682.png)](https://gyazo.com/e4045a22188203686cbcecbcded96682)
- [ ] アラーム作成画面に下記のように、必須項目と補足説明がついている。
[![Image from Gyazo](https://i.gyazo.com/c84b0e5fdbc0239268fdf75c98cc5519.png)](https://gyazo.com/c84b0e5fdbc0239268fdf75c98cc5519)
- [ ] アラーム編集画面に下記のように、必須項目と補足説明がついている。
[![Image from Gyazo](https://i.gyazo.com/806b3919d86283cb0f5f141edd8f5954.png)](https://gyazo.com/806b3919d86283cb0f5f141edd8f5954)