### PR TITLE
fix: ログアウト時の定型文一覧画面のエラー修正

### DIFF
--- a/app/controllers/message_templates_controller.rb
+++ b/app/controllers/message_templates_controller.rb
@@ -8,8 +8,14 @@ class MessageTemplatesController < ApplicationController
   skip_before_action :authenticate_user!, only: [ :index ]
 
   def index
-    # デフォルトデータと、自分で作成したもののみ取得
-    @message_templates = MessageTemplate.where(user_id: [ current_user.id, nil ])
+    if user_signed_in?
+      # デフォルトデータと、自分で作成したもののみ取得
+      @message_templates = MessageTemplate.where(user_id: [ current_user.id, nil ])
+
+    else
+      # デフォルトデータのみ取得
+      @message_templates = MessageTemplate.where(user_id: nil)
+    end
   end
 
   def new


### PR DESCRIPTION
## 解決した問題
message_templates_controller.rbのindexアクションで、ログイン時とログアウト時のデータの取得を条件分岐していなかったため、ログアウト時に定型文一覧画面を開くとエラーが発生していた。