### PR TITLE
fix: メールテンプレートで、URLを表示

### DIFF
--- a/app/views/alarm_mailer/alarm_notification.html.erb
+++ b/app/views/alarm_mailer/alarm_notification.html.erb
@@ -6,10 +6,10 @@
 キリの良いところで終了しましょう！
 </h3>
 <h3>
-  <%= link_to "アラームストップページ",
-              pending_alarms_url,
-              target: '_blank',
-              rel: 'noopener noreferrer' %>
+  アラームストップページ： <%= link_to pending_alarms_url,
+                                    pending_alarms_url,
+                                    target: '_blank',
+                                    rel: 'noopener noreferrer' %>
 </h3>
 
 <hr>

--- a/app/views/alarm_mailer/alarm_notification.text.erb
+++ b/app/views/alarm_mailer/alarm_notification.text.erb
@@ -5,10 +5,7 @@
 キリの良いところで終了しましょう！
 
 
-<%= link_to "アラームストップページ",
-            pending_alarms_url,
-            target: '_blank',
-            rel: 'noopener noreferrer' %>
+アラームストップページ： <%= pending_alarms_url %>
 
 ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## 対応issue
close #181 
## 備考
text.erbのリンクをlink_to（text形式では無効）で書いていたため、修正した。