### PR TITLE
refactor: simple-calendarのimportantの部分を@layer componentsに置き換え

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,3 +1,5 @@
+/* app/assets/stylesheets/application.tailwind.css */
+
 @import "tailwindcss";
 @import "./pagy-tailwind.css";
 
@@ -22,23 +24,25 @@
   --cal-othermonth-text: rgb(113 113 122);
 }
 
-.simple-calendar,
-.simple-calendar table {
-  display: table !important;
-  width: 100% !important;
-  table-layout: fixed !important;
-  border-collapse: collapse !important;
-}
+@layer components {
+  .simple-calendar,
+  .simple-calendar table {
+    display: table;
+    width: 100%;
+    table-layout: fixed;
+    border-collapse: collapse;
+  }
 
-.simple-calendar thead { display: table-header-group !important; }
+  .simple-calendar thead { display: table-header-group; }
 
-.simple-calendar thead tr,
-.simple-calendar tbody tr { display: table-row !important; }
+  .simple-calendar thead tr,
+  .simple-calendar tbody tr { display: table-row; }
 
-.simple-calendar thead th,
-.simple-calendar tbody td {
-  display: table-cell !important;
-  width: 14.28%;
+  .simple-calendar thead th,
+  .simple-calendar tbody td {
+    display: table-cell;
+    width: 14.28%;
+  }
 }
 
 .simple-calendar tbody td {

--- a/app/assets/stylesheets/pagy-tailwind.css
+++ b/app/assets/stylesheets/pagy-tailwind.css
@@ -1,4 +1,4 @@
-/* app/assets/tailwind/pagy-tailwind.css */
+/* app/assets/stylesheets/pagy-tailwind.css */
 
 @layer components {
   .pagy {


### PR DESCRIPTION
close #456 
## 備考
- cssのコード自体にセキュリティ面での問題は見受けられなかった
- 「important」の部分は、「@layer components」に置き換えた方が、今後の展開がしやすいと考え置き換えた