### PR TITLE
fix: AlarmMemberジョブ の処理順を修正

### DIFF
--- a/app/jobs/alarm_member_notification_job.rb
+++ b/app/jobs/alarm_member_notification_job.rb
@@ -28,8 +28,6 @@ class AlarmMemberNotificationJob < ApplicationJob
       return
     end
 
-    membership.update!(notified: true)
-
     user = User.find_by(uuid: user_uuid)
     unless user
       Rails.logger.warn("[AlarmMemberNotificationJob] ユーザーが見つかりません uuid=#{user_uuid}")
@@ -38,6 +36,7 @@ class AlarmMemberNotificationJob < ApplicationJob
 
     Rails.logger.info("[AlarmMemberNotificationJob] send_push_notification を呼び出します user=#{user_uuid}")
     send_push_notification(user, build_alarm_payload(alarm, membership))
+    membership.update!(notified: true)
   end
 
   private

--- a/app/jobs/alarm_member_reminder_job.rb
+++ b/app/jobs/alarm_member_reminder_job.rb
@@ -17,13 +17,11 @@ class AlarmMemberReminderJob < ApplicationJob
     # 通知済みかどうかのチェック
     return if membership.reminder_notified?
 
-    # メール・プッシュ通知より先に送信済みとして記録（エラー時のリトライによる二重送信対策）
-    membership.update!(reminder_notified: true)
-
     user = User.find_by(uuid: user_uuid)
     return unless user
 
     send_push_notification(user, build_reminder_payload(alarm, minutes_until_alarm, membership))
+    membership.update!(reminder_notified: true)
   end
 
   private

--- a/spec/jobs/alarm_member_notification_job_spec.rb
+++ b/spec/jobs/alarm_member_notification_job_spec.rb
@@ -99,5 +99,10 @@ RSpec.describe AlarmMemberNotificationJob, type: :job do
       expect(WebPush).not_to receive(:payload_send)
       described_class.perform_now(alarm.uuid, user.uuid)
     end
+
+    it "notified が true にならない" do
+      described_class.perform_now(alarm.uuid, user.uuid)
+      expect(membership.reload.notified).to be false
+    end
   end
 end

--- a/spec/jobs/alarm_member_reminder_job_spec.rb
+++ b/spec/jobs/alarm_member_reminder_job_spec.rb
@@ -100,5 +100,10 @@ RSpec.describe AlarmMemberReminderJob, type: :job do
       expect(WebPush).not_to receive(:payload_send)
       described_class.perform_now(alarm.uuid, user.uuid, minutes_until_alarm)
     end
+
+    it "reminder_notified が true にならない" do
+      described_class.perform_now(alarm.uuid, user.uuid, minutes_until_alarm)
+      expect(membership.reload.reminder_notified).to be false
+    end
   end
 end


### PR DESCRIPTION
## 対応issue
close #575 
## 備考
membership.update!(notified: true) を send_push_notification の呼び出しより後に移動した。これにより、send_push_notification に到達しないケースで notified が意図せず true に更新される問題を防止するように設定した。