### PR TITLE
feat: turbo_stream の prepend・replace を update に変更する

### DIFF
--- a/app/controllers/alarms_controller.rb
+++ b/app/controllers/alarms_controller.rb
@@ -8,18 +8,7 @@ class AlarmsController < ApplicationController
   # 一覧・表示系アクション
   #=================================================
   def index
-    @memberships = current_user.alarm_memberships
-                              .not_stopped_by(current_user)
-                              .joins(:alarm)
-                              .merge(Alarm.unsent.future.not_stopped)
-                              .includes(
-                                alarm: [
-                                  { creator: { avatar_attachment: :blob } },
-                                  { members: { avatar_attachment: :blob } },
-                                  :alarm_memberships
-                                ]
-                              )
-                              .order("alarms.scheduled_at asc")
+    @memberships = index_memberships
   end
 
   # カレンダー
@@ -29,7 +18,7 @@ class AlarmsController < ApplicationController
 
   # 未ストップ（でかつストップ可能な）アラームの表示
   def pending
-    @alarm_memberships = pending_alarm_memberships
+    @pending_memberships = pending_alarm_memberships
   end
 
   #=================================================
@@ -64,15 +53,9 @@ class AlarmsController < ApplicationController
     if @alarm.save
       check_pwa_install_prompt
 
-      # リストへのajaxでの追加のために作成直後の membership を取得する。
       @membership = @alarm.alarm_memberships.find_by(user: current_user)
-
-      # pending画面に追加すべきかの判定に使用
-      @add_to_pending = current_user.alarm_memberships
-                                      .not_stopped_by(current_user)
-                                      .joins(:alarm)
-                                      .merge(Alarm.not_stopped.stoppable_now)
-                                      .exists?(@membership.id)
+      @memberships = index_memberships
+      @pending_memberships = pending_alarm_memberships
 
       respond_to do |format|
         format.turbo_stream do
@@ -97,6 +80,7 @@ class AlarmsController < ApplicationController
   def update
     if @alarm.update(alarm_params)
       @membership = @alarm.alarm_memberships.find_by(user: current_user)
+      @memberships = index_memberships
 
       respond_to do |format|
         format.turbo_stream do
@@ -120,6 +104,7 @@ class AlarmsController < ApplicationController
 
     # メンバーシップが存在しない場合
     if membership.nil?
+      @pending_memberships = pending_alarm_memberships
       flash.now[:alert] = "アラームをストップできませんでした"
       render "alarms/pending", status: :unprocessable_entity
       return
@@ -157,6 +142,21 @@ class AlarmsController < ApplicationController
   # ストロングパラメータ
   def alarm_params
     params.require(:alarm).permit(:label, :scheduled_at, :started_at, :reminder_minutes)
+  end
+
+  def index_memberships
+    current_user.alarm_memberships
+                .not_stopped_by(current_user)
+                .joins(:alarm)
+                .merge(Alarm.unsent.future.not_stopped)
+                .includes(
+                  alarm: [
+                    { creator: { avatar_attachment: :blob } },
+                    { members: { avatar_attachment: :blob } },
+                    :alarm_memberships
+                  ]
+                )
+                .order("alarms.scheduled_at asc")
   end
 
   # 未ストップ（でかつストップ可能な）アラームの表示
@@ -203,7 +203,7 @@ class AlarmsController < ApplicationController
                           ).
                           order(scheduled_at: :asc)
 
-    @alarm_memberships = pending_alarm_memberships
+    @pending_memberships = pending_alarm_memberships
 
     flash.now[:alert] = "アラームをストップできませんでした"
     render "alarms/pending", status: :unprocessable_entity

--- a/app/views/alarms/create.turbo_stream.erb
+++ b/app/views/alarms/create.turbo_stream.erb
@@ -1,21 +1,13 @@
 <%# app/views/alarms/create.turbo_stream.erb %>
 
 <%# indexページ用 %>
-<!-- リストの更新 -->
-<%= turbo_stream.prepend "alarms_list",
-      partial: "alarms/index/membership_row",
-      locals: { membership: @membership } %>
-<%# 空状態メッセージが存在する場合は削除 %>
-<%= turbo_stream.remove "no_alarms_message" %>
+<%= turbo_stream.update "alarms_list" do %>
+  <%= render 'alarms/index/list', memberships: @memberships %>
+<% end %>
 
 <%# pendingページ用 %>
-<% if @add_to_pending %>
-  <!-- リストの更新 -->
-  <%= turbo_stream.prepend "pending_alarms_list",
-        partial: "alarms/pending/membership_row",
-        locals: { membership: @membership } %>
-  <%# 空状態メッセージが存在する場合は削除 %>
-  <%= turbo_stream.remove "pending_no_alarms_message" %>
+<%= turbo_stream.update "pending_alarms_list" do %>
+  <%= render 'alarms/pending/list', memberships: @pending_memberships.values %>
 <% end %>
 
 <!-- フラッシュメッセージの表示 -->
@@ -24,9 +16,7 @@
 <%# ダイアログ（作成フォーム）をupdateで空にすることで閉じる %>
 <%= turbo_stream.update "dialog" %>
 
-
-
-<%# 3. PWAインストールの案内が必要なときだけ差し込む %>
+<%# PWAインストールの案内が必要なときだけ差し込む %>
 <% if flash[:show_pwa_install_prompt] %>
   <%= turbo_stream.append "push_notification_modal", partial: "shared/pwa_install_prompt" %>
 <% end %>

--- a/app/views/alarms/index.html.erb
+++ b/app/views/alarms/index.html.erb
@@ -50,32 +50,5 @@
 
 <%# アラームリスト %>
 <div id="alarms_list" class="pb-64">
-  <% if @memberships.present? %>
-    <div class="bg-white dark:bg-gray-950
-                rounded-xl
-                border border-gray-200 dark:border-gray-800
-                divide-y divide-gray-100 dark:divide-gray-800">
-
-      <%# scheduled_at の日付でグループ化して日付ヘッダーを挟む %>
-      <% @memberships.group_by { |m| m.alarm.scheduled_at.to_date }.each do |date, memberships| %>
-
-        <%# 日付ヘッダー行 %>
-        <div class="px-5 py-2
-                    bg-gray-100 dark:bg-gray-900/40">
-          <span class="text-sm font-medium text-gray-800 dark:text-gray-400">
-            <%= date.strftime("%-m/%-d") %>（<%= %w[日 月 火 水 木 金 土][date.wday] %>）
-          </span>
-        </div>
-
-        <!-- 各アラームの表示 -->
-        <% memberships.each do |membership| %>
-          <%= render 'alarms/index/membership_row', membership: membership %>
-        <% end %>
-
-      <% end %>
-    </div>
-  <% else %>
-    <!-- アラームがない場合に表示するもの -->
-    <%= render 'alarms/index/no_alarms_message' %>
-  <% end %>
+  <%= render 'alarms/index/list', memberships: @memberships %>
 </div>

--- a/app/views/alarms/index/_list.html.erb
+++ b/app/views/alarms/index/_list.html.erb
@@ -1,0 +1,20 @@
+<%# app/views/alarms/index/_list.html.erb %>
+<% if memberships.present? %>
+  <div class="bg-white dark:bg-gray-950
+              rounded-xl
+              border border-gray-200 dark:border-gray-800
+              divide-y divide-gray-100 dark:divide-gray-800">
+    <% memberships.group_by { |m| m.alarm.scheduled_at.to_date }.each do |date, group| %>
+      <div class="px-5 py-2 bg-gray-100 dark:bg-gray-900/40">
+        <span class="text-sm font-medium text-gray-800 dark:text-gray-400">
+          <%= date.strftime("%-m/%-d") %>（<%= %w[日 月 火 水 木 金 土][date.wday] %>）
+        </span>
+      </div>
+      <% group.each do |membership| %>
+        <%= render 'alarms/index/membership_row', membership: membership %>
+      <% end %>
+    <% end %>
+  </div>
+<% else %>
+  <%= render 'alarms/index/no_alarms_message' %>
+<% end %>

--- a/app/views/alarms/pending.html.erb
+++ b/app/views/alarms/pending.html.erb
@@ -62,32 +62,7 @@
 
   <%# pb-64 でスクロール余白あり（index画面と統一） %>
   <div id="pending_alarms_list" class="pb-64">
-    <% if @alarm_memberships.present? %>
-      <div class="bg-white dark:bg-gray-950
-                  rounded-xl
-                  border border-gray-200 dark:border-gray-800
-                  divide-y divide-gray-100 dark:divide-gray-800">
-
-        <%# scheduled_at（アラームの設定時刻） の日付でグループ化 %>
-        <% @alarm_memberships.values.group_by { |m| m.alarm.scheduled_at.to_date }.each do |date, memberships| %>
-
-          <div class="px-5 py-2 bg-gray-100 dark:bg-gray-900/40">
-            <span class="text-sm font-medium text-gray-800 dark:text-gray-400">
-              <%= date.strftime("%-m/%-d") %>（<%= %w[日 月 火 水 木 金 土][date.wday] %>）
-            </span>
-          </div>
-
-          <!-- 各アラームをレンダリング -->
-          <% memberships.each do |membership| %>
-            <%= render 'alarms/pending/membership_row', membership: membership %>
-          <% end %>
-
-        <% end %>
-      </div>
-    <% else %>
-      <!-- アラームがない場合に表示するもの -->
-      <%= render 'alarms/pending/no_alarms_message' %>
-    <% end %>
+    <%= render 'alarms/pending/list', memberships: @pending_memberships.values %>
   </div>
 
 </div>

--- a/app/views/alarms/pending/_list.html.erb
+++ b/app/views/alarms/pending/_list.html.erb
@@ -1,0 +1,20 @@
+<%# app/views/alarms/pending/_list.html.erb %>
+<% if memberships.present? %>
+  <div class="bg-white dark:bg-gray-950
+              rounded-xl
+              border border-gray-200 dark:border-gray-800
+              divide-y divide-gray-100 dark:divide-gray-800">
+    <% memberships.group_by { |m| m.alarm.scheduled_at.to_date }.each do |date, group| %>
+      <div class="px-5 py-2 bg-gray-100 dark:bg-gray-900/40">
+        <span class="text-sm font-medium text-gray-800 dark:text-gray-400">
+          <%= date.strftime("%-m/%-d") %>（<%= %w[日 月 火 水 木 金 土][date.wday] %>）
+        </span>
+      </div>
+      <% group.each do |membership| %>
+        <%= render 'alarms/pending/membership_row', membership: membership %>
+      <% end %>
+    <% end %>
+  </div>
+<% else %>
+  <%= render 'alarms/pending/no_alarms_message' %>
+<% end %>

--- a/app/views/alarms/update.turbo_stream.erb
+++ b/app/views/alarms/update.turbo_stream.erb
@@ -1,15 +1,14 @@
 <%# app/views/alarms/update.turbo_stream.erb %>
 
-<%# リスト行の更新：一覧画面（indexやpending）内の該当する行を最新状態に差し替え %>
-<%= turbo_stream.replace dom_id(@membership),
-      partial: "alarms/index/membership_row",
-      locals: { membership: @membership } %>
+<%# indexページ用 %>
+<%= turbo_stream.update "alarms_list" do %>
+  <%= render 'alarms/index/list', memberships: @memberships %>
+<% end %>
 
 <%# 詳細画面の更新 %>
 <%= turbo_stream.replace "alarm_detail_#{@alarm.id}",
       partial: "alarm_memberships/alarm_detail",
       locals: { alarm: @alarm } %>
-
 
 <!-- フラッシュメッセージの表示 -->
 <%= render_turbo_stream_flash_messages %>


### PR DESCRIPTION
## 概要
アラームのリストのajax更新の方法を「一列の追加・更新」から「リスト全体の更新」に変更。
## 対応issue
close #576 