### PR TITLE
refactor: pending_alarm_memberships の index_by を削除する

### DIFF
--- a/app/controllers/alarms_controller.rb
+++ b/app/controllers/alarms_controller.rb
@@ -170,7 +170,6 @@ class AlarmsController < ApplicationController
                   alarm: [ :alarm_memberships, { members: :avatar_attachment }, { creator: :avatar_attachment } ]
                 )
                 .order("alarms.scheduled_at ASC")
-                .index_by(&:alarm_uuid)
   end
 
   def load_calendar_data

--- a/app/views/alarms/create.turbo_stream.erb
+++ b/app/views/alarms/create.turbo_stream.erb
@@ -7,7 +7,7 @@
 
 <%# pendingページ用 %>
 <%= turbo_stream.update "pending_alarms_list" do %>
-  <%= render 'alarms/pending/list', memberships: @pending_memberships.values %>
+  <%= render 'alarms/pending/list', memberships: @pending_memberships %>
 <% end %>
 
 <!-- フラッシュメッセージの表示 -->

--- a/app/views/alarms/pending.html.erb
+++ b/app/views/alarms/pending.html.erb
@@ -62,7 +62,7 @@
 
   <%# pb-64 でスクロール余白あり（index画面と統一） %>
   <div id="pending_alarms_list" class="pb-64">
-    <%= render 'alarms/pending/list', memberships: @pending_memberships.values %>
+    <%= render 'alarms/pending/list', memberships: @pending_memberships %>
   </div>
 
 </div>


### PR DESCRIPTION
## 概要
controllers/alarms_controllerの`pending_alarm_memberships` の `index_by` を削除
## 対応issue
close #577 