### PR TITLE
chore: CIの 「postgres イメージをバージョン固定」＆「ジョブの依存関係を追加する」

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,11 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    needs: [scan_ruby, lint]
 
     services:
       postgres:
-        image: postgres
+        image: postgres:17 # バージョン固定
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -109,10 +110,11 @@ jobs:
 
   system-test:
     runs-on: ubuntu-latest
+    needs: [scan_ruby, lint, test]
 
     services:
       postgres:
-        image: postgres
+        image: postgres:17 # バージョン固定
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
## 概要
CIの 「postgres イメージをバージョン固定」＆「ジョブの依存関係を追加」
## 対応issue
close #588 